### PR TITLE
explicit options in fn sig of execFile

### DIFF
--- a/lib/js/src/child_process.js
+++ b/lib/js/src/child_process.js
@@ -18,7 +18,42 @@ function execSync(cmd) {
   return Buffer$LidcoreBsNode.toString(Child_process.execSync(cmd));
 }
 
-function execFile(cmd, args, options, cb) {
+function execFile(cmd, args, cwd, env, encoding, timeout, maxBuffer, killSignal, uid, gid, windowsHide, windowsVerbatimOptions, shell, cb) {
+  var tmp = { };
+  if (cwd) {
+    tmp.cwd = cwd[0];
+  }
+  if (env) {
+    tmp.env = env[0];
+  }
+  if (encoding) {
+    tmp.encoding = encoding[0];
+  }
+  if (timeout) {
+    tmp.timeout = timeout[0];
+  }
+  if (maxBuffer) {
+    tmp.maxBuffer = maxBuffer[0];
+  }
+  if (killSignal) {
+    tmp.killSignal = killSignal[0];
+  }
+  if (uid) {
+    tmp.uid = uid[0];
+  }
+  if (gid) {
+    tmp.gid = gid[0];
+  }
+  if (windowsHide) {
+    tmp.windowsHide = windowsHide[0];
+  }
+  if (windowsVerbatimOptions) {
+    tmp.windowsVerbatimOptions = windowsVerbatimOptions[0];
+  }
+  if (shell) {
+    tmp.shell = shell[0];
+  }
+  var options = tmp;
   Child_process.execFile(cmd, args, options, (function (err, stdout, stderr) {
           return cb(err, /* tuple */[
                       stdout,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lidcore/bs-node",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lidcore/bs-node",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Very Partial Bindings to node for bucklescript applications",
   "scripts": {
     "build": "bsb -make-world",

--- a/src/child_process.ml
+++ b/src/child_process.ml
@@ -28,6 +28,8 @@ type execFileOptions =
 external execFile :
   string -> string array -> execFileOptions -> 'a callback -> unit = "" [@@bs.module "child_process"]
 
-let execFile cmd args options cb =
+let execFile cmd args ?cwd ?env ?encoding ?timeout ?maxBuffer ?killSignal ?uid ?gid ?windowsHide ?windowsVerbatimOptions ?shell cb =
+  let options = execFileOptions ?cwd:cwd ?env:env ?encoding:encoding ?timeout:timeout ?maxBuffer:maxBuffer ?killSignal:killSignal ?uid: uid ?gid:gid ?windowsHide: windowsHide ?windowsVerbatimOptions:windowsVerbatimOptions ?shell:shell ()
+  in
   execFile cmd args options (fun [@bs] err stdout stderr ->
       cb err (stdout, stderr) [@bs])

--- a/src/child_process.ml
+++ b/src/child_process.ml
@@ -28,8 +28,8 @@ type execFileOptions =
 external execFile :
   string -> string array -> execFileOptions -> 'a callback -> unit = "" [@@bs.module "child_process"]
 
-let execFile cmd args ?cwd ?env ?encoding ?timeout ?maxBuffer ?killSignal ?uid ?gid ?windowsHide ?windowsVerbatimOptions ?shell cb =
-  let options = execFileOptions ?cwd:cwd ?env:env ?encoding:encoding ?timeout:timeout ?maxBuffer:maxBuffer ?killSignal:killSignal ?uid: uid ?gid:gid ?windowsHide: windowsHide ?windowsVerbatimOptions:windowsVerbatimOptions ?shell:shell ()
+let execFile ?cwd ?env ?encoding ?timeout ?maxBuffer ?killSignal ?uid ?gid ?windowsHide ?windowsVerbatimOptions ?shell cmd args cb =
+  let options = execFileOptions ?cwd ?env ?encoding ?timeout ?maxBuffer ?killSignal ?uid ?gid ?windowsHide ?windowsVerbatimOptions ?shell ()
   in
   execFile cmd args options (fun [@bs] err stdout stderr ->
       cb err (stdout, stderr) [@bs])

--- a/src/child_process.mli
+++ b/src/child_process.mli
@@ -2,4 +2,4 @@ type execFileOptions
 
 val exec : string -> (string*string) BsCallback.t
 val execSync : string -> string
-val execFile: string -> string array -> execFileOptions -> (string*string) BsCallback.t
+val execFile: string -> string array -> ?cwd:string -> ?env:string Js.Dict.t -> ?encoding:string -> ?timeout:int -> ?maxBuffer:float -> ?killSignal:string -> ?uid:int -> ?gid:int -> ?windowsHide:bool -> ?windowsVerbatimOptions:bool -> ?shell:string -> (string*string) BsCallback.t


### PR DESCRIPTION
I wasn't quite sure how to properly destructure the options, or whether that is even idiomatic in ocaml.  Is the better way to make them explicit optional args as in this PR?  feedback appreciated, thanks!